### PR TITLE
map Y to B for international keyboard, fix #9

### DIFF
--- a/source/keyboard.js
+++ b/source/keyboard.js
@@ -45,6 +45,7 @@ JSNES.Keyboard.prototype = {
     setKey: function(key, value) {
         switch (key) {
             case 88: this.state1[this.keys.KEY_A] = value; break;      // X
+            case 89: this.state1[this.keys.KEY_B] = value; break;      // Y (Central European keyboard)
             case 90: this.state1[this.keys.KEY_B] = value; break;      // Z
             case 17: this.state1[this.keys.KEY_SELECT] = value; break; // Right Ctrl
             case 13: this.state1[this.keys.KEY_START] = value; break;  // Enter


### PR DESCRIPTION
There are some countries such as Germany where the Z and Y keys are switched around: https://en.wikipedia.org/wiki/Keyboard_layout#QWERTZ

To not need to hold your hand in such a weird way, not only Z but also Y is mapped to B.
