### PR TITLE
Update mappers.js

### DIFF
--- a/source/mappers.js
+++ b/source/mappers.js
@@ -250,7 +250,7 @@ JSNES.Mappers[0].prototype = {
             
             case 0x4016:
                 // Joystick 1 + Strobe
-                if (value === 0 && this.joypadLastWrite === 1) {
+                if ((value&1) === 0 && (this.joypadLastWrite&1) === 1) {
                     this.joy1StrobeState = 0;
                     this.joy2StrobeState = 0;
                 }


### PR DESCRIPTION
When I code NES games, I often use the following code in order to handle the controller:

```
        LDX #9
        STX $4016
        DEX
        STX $4016
    loop:
        LDA $4016
        DEX
        BNE loop
```

This works because when I write a 9 followed by an 8 to the controller, the only bit that actually counts is the LSB. The original code requires me to write exactly a 1, but that seems restrictive, and is not consistent with other emulators.
