### PR TITLE
Skip rendering if no tile

### DIFF
--- a/source/ppu.js
+++ b/source/ppu.js
@@ -1003,11 +1003,17 @@ JSNES.PPU.prototype = {
                     if (this.validTileData) {
                         // Get data from array:
                         t = scantile[tile];
+                        if (typeof t === 'undefined') {
+                            continue;
+                        }
                         tpix = t.pix;
                         att = attrib[tile];
                     }else {
                         // Fetch data:
                         t = ptTile[baseTile+nameTable[this.curNt].getTileIndex(this.cntHT,this.cntVT)];
+                        if (typeof t === 'undefined') {
+                            continue;
+                        }
                         tpix = t.pix;
                         att = nameTable[this.curNt].getAttrib(this.cntHT,this.cntVT);
                         scantile[tile] = t;


### PR DESCRIPTION
When I was trying to play Ninja Gaiden III, it got stuck at the beginning with a grey screen.

I believe rendeBgScanline was trying to fetch tile from nameTable, but for this game the first few frames don't actually write to VRAM (0x2007) thus nothing has been written to the nametable...

I have very limited knowledge of NES so please correct me if I'm wrong. Thanks!
