### PR TITLE
Made screen not blurry when stretched.

### DIFF
--- a/source/ui.js
+++ b/source/ui.js
@@ -43,6 +43,10 @@ if (typeof jQuery !== 'undefined') {
                     return;
                 }
                 
+                // Don't blur the screen when resized
+                self.screen[0].style.imageRendering = "-moz-crisp-edges";
+                self.screen[0].style.imageRendering = "pixelated";
+
                 self.romContainer = $('<div class="nes-roms"></div>').appendTo(self.root);
                 self.romSelect = $('<select></select>').appendTo(self.romContainer);
                 


### PR DESCRIPTION
For some reason Firefox and Chrome blur a stretched canvas by default. It can now be turned off with CSS. Funny thing is the blurring actually slows things down a bit. So it is faster, and looks better(IMHO) to not blur.

Left: Default blurring, Right: No blurring
![no_blurry](https://cloud.githubusercontent.com/assets/2733986/26090221/497a1e48-39b8-11e7-8032-0c4d13e598fb.jpg)

Do you like this?