### PR TITLE
Remove onBatteryRamWrite console logging

### DIFF
--- a/src/mappers.js
+++ b/src/mappers.js
@@ -25,7 +25,7 @@ Mappers[0].prototype = {
       this.nes.cpu.mem[address] = value;
       if (address >= 0x6000 && address < 0x8000) {
         // Write to persistent RAM
-        this.nes.opts.onBatteryRamWrite(address.toString(16), value.toString(16));
+        this.nes.opts.onBatteryRamWrite(address, value);
       }
     } else if (address > 0x2007 && address < 0x4000) {
       this.regWrite(0x2000 + (address & 0x7), value);

--- a/src/mappers.js
+++ b/src/mappers.js
@@ -25,12 +25,7 @@ Mappers[0].prototype = {
       this.nes.cpu.mem[address] = value;
       if (address >= 0x6000 && address < 0x8000) {
         // Write to persistent RAM
-        console.log(
-          "onBatteryRamWrite",
-          address.toString(16),
-          value.toString(16)
-        );
-        this.nes.opts.onBatteryRamWrite(address, value);
+        this.nes.opts.onBatteryRamWrite(address.toString(16), value.toString(16));
       }
     } else if (address > 0x2007 && address < 0x4000) {
       this.regWrite(0x2000 + (address & 0x7), value);


### PR DESCRIPTION
If a user wants to see this output they can provide `onBatteryRamWrite: console.log` as an option when creating a NES instance. Removing this forced console.log keeps the console clean for debugging.