### PR TITLE
Add Node.js ROM loading example

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ var nes = new jsnes.NES({
 
 // Load ROM data as a string or byte array
 nes.loadROM(romData);
+// An example of loading ROM data in Node.js
+var romData = require('fs').readFileSync('path/to/rom.nes', { encoding: 'binary' });
 
 // Run frames at 60 fps, or as fast as you can.
 // You are responsible for reliable timing as best you can on your platform.


### PR DESCRIPTION
As noted in issue #113 it isn't obvious that files need to be loaded using `binary` encoding in a Node environment, adding an example to the Readme should help clarify this