### PR TITLE
Add test for correct frame buffer output

### DIFF
--- a/test/nes.spec.js
+++ b/test/nes.spec.js
@@ -13,11 +13,27 @@ describe("NES", function() {
     var nes = new NES({ onFrame: onFrame });
     fs.readFile("roms/croom/croom.nes", function(err, data) {
       if (err) return done(err);
-      nes.loadROM(data.toString("ascii"));
+      nes.loadROM(data.toString("binary"));
       nes.frame();
       assert(onFrame.calledOnce);
       assert.isArray(onFrame.args[0][0]);
       assert.lengthOf(onFrame.args[0][0], 256 * 240);
+      done();
+    });
+  });
+
+  it("generates the correct frame buffer", function(done) {
+    var onFrame = sinon.spy();
+    var nes = new NES({ onFrame: onFrame });
+    fs.readFile("roms/croom/croom.nes", function(err, data) {
+      if (err) return done(err);
+      nes.loadROM(data.toString("binary"));
+      var pixIndexes = [];
+      for (var i = 0; i < 6; i++) {
+        nes.frame();
+        pixIndexes.push(onFrame.args[i][0].indexOf(16777215))
+      }
+      assert.deepEqual(pixIndexes, [-1, -1, -1, 2056, 4104, 4104]);
       done();
     });
   });
@@ -36,7 +52,7 @@ describe("NES", function() {
     before(function(done) {
       fs.readFile("roms/croom/croom.nes", function(err, data) {
         if (err) return done(err);
-        nes.loadROM(data.toString("ascii"));
+        nes.loadROM(data.toString("binary"));
         done();
       });
     });


### PR DESCRIPTION
This adds a new test to check that the frame buffer is actually generating the correct frames using the existing Croom.nes ROM. Some files will load and generate "frames" and a "frame rate" but will become stuck at the initial screen (a black border and grey box). This test helps to detect this issue (originally reported as #113)

This also fixes the file loading in the test cases to use `binary` instead of `ascii` encoding which causes the problem.

The test works by checking the first index of a certain color pixel (white) on the first 6 frames of output. Croom only uses 2 colors on the initial screen which makes it easy to detect. Comparing full snapshots of each frame takes too long.