### PR TITLE
Add support for mapper 94

### DIFF
--- a/src/mappers.js
+++ b/src/mappers.js
@@ -1408,6 +1408,47 @@ Mappers[66].prototype.write = function(address, value) {
 };
 
 /**
+ * Mapper 094 (UN1ROM)
+ *
+ * @description http://wiki.nesdev.com/w/index.php/INES_Mapper_094
+ * @example Senjou no Ookami
+ * @constructor
+ */
+Mappers[94] = function(nes) {
+  this.nes = nes;
+};
+
+Mappers[94].prototype = new Mappers[0]();
+
+Mappers[94].prototype.write = function(address, value) {
+  // Writes to addresses other than MMC registers are handled by NoMapper.
+  if (address < 0x8000) {
+    Mappers[0].prototype.write.apply(this, arguments);
+    return;
+  } else {
+    // This is a ROM bank select command.
+    // Swap in the given ROM bank at 0x8000:
+    this.loadRomBank(value >> 2, 0x8000);
+  }
+};
+
+Mappers[94].prototype.loadROM = function() {
+  if (!this.nes.rom.valid) {
+    throw new Error("UN1ROM: Invalid ROM! Unable to load.");
+  }
+
+  // Load PRG-ROM:
+  this.loadRomBank(0, 0x8000);
+  this.loadRomBank(this.nes.rom.romCount - 1, 0xc000);
+
+  // Load CHR-ROM:
+  this.loadCHRROM();
+
+  // Do Reset-Interrupt:
+  this.nes.cpu.requestIrq(this.nes.cpu.IRQ_RESET);
+};
+
+/**
  * Mapper 180
  *
  * @description http://wiki.nesdev.com/w/index.php/INES_Mapper_180


### PR DESCRIPTION
Trying to see if there are any obscure mappers that aren't too difficult to implement and helping out with them. Here's mapper 94, used only in Senjou no Ookami (the Japanese version of Commando). It's just a slightly modified UNROM wherein the bank select register is shifted by 2 bits.

<img width="952" alt="screen shot 2018-10-27 at 21 55 06" src="https://user-images.githubusercontent.com/10043207/47611104-555b4700-da34-11e8-8034-62a894705f0b.png">
