### PR TITLE
Add support for mapper 140

### DIFF
--- a/src/mappers.js
+++ b/src/mappers.js
@@ -1449,6 +1449,32 @@ Mappers[94].prototype.loadROM = function() {
 };
 
 /**
+ * Mapper 140
+ *
+ * @description http://wiki.nesdev.com/w/index.php/INES_Mapper_140
+ * @example Bio Senshi Dan - Increaser Tono Tatakai
+ * @constructor
+ */
+Mappers[140] = function(nes) {
+  this.nes = nes;
+};
+
+Mappers[140].prototype = new Mappers[0]();
+
+Mappers[140].prototype.write = function(address, value) {
+  if (address < 0x6000 || address > 0x7fff) {
+    Mappers[0].prototype.write.apply(this, arguments);
+    return;
+  } else {
+    // Swap in the given PRG-ROM bank at 0x8000:
+    this.load32kRomBank((value >> 4) & 3, 0x8000);
+
+    // Swap in the given VROM bank at 0x0000:
+    this.load8kVromBank((value & 0xf) * 2, 0x0000);
+  }
+};
+
+/**
  * Mapper 180
  *
  * @description http://wiki.nesdev.com/w/index.php/INES_Mapper_180


### PR DESCRIPTION
Trying to see if there are any obscure mappers that aren't too difficult to implement and helping out with them. Here's mapper 140, used in games with Jaleco's JF-11 and JF-14 boards. It's identical to GNROM with the exception of the location of the bank select register.

<img width="952" alt="screen shot 2018-10-27 at 22 52 40" src="https://user-images.githubusercontent.com/10043207/47611423-9145da80-da3b-11e8-8758-0663ed3a54f3.png">
