### PR TITLE
v1.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsnes",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A JavaScript NES emulator",
   "homepage": "https://github.com/bfirsh/jsnes",
   "author": "Ben Firshman <ben@firshman.co.uk> (https://fir.sh)",

--- a/src/nes.js
+++ b/src/nes.js
@@ -200,10 +200,11 @@ NES.prototype = {
   },
 
   fromJSON: function (s) {
-    this.loadROM(s.romData);
-    this.cpu.fromJSON(s.cpu);
-    this.mmap.fromJSON(s.mmap);
-    this.ppu.fromJSON(s.ppu);
+      this.reset();
+      this.romData = s.romData;
+      this.cpu.fromJSON(s.cpu);
+      this.mmap.fromJSON(s.mmap);
+      this.ppu.fromJSON(s.ppu);
   },
 };
 


### PR DESCRIPTION
* fixed nes.fromJSON graphic glitch:
   https://github.com/bfirsh/jsnes/issues/16

Calling `this.loadROM(s.romData)` in fromJSON was doing too much and causing the graphic glitches:
```
    this.mmap = this.rom.createMapper();
    this.mmap.loadROM();
    this.ppu.setMirroring(this.rom.getMirroringType());
```
When a ROM is already loaded in the emulator, only the following should execute to load the save state:
```
fromJSON: function (s) {
    this.reset();
    this.romData = s.romData;
    this.cpu.fromJSON(s.cpu);
    this.mmap.fromJSON(s.mmap);
    this.ppu.fromJSON(s.ppu);
}
```
If a ROM has not yet been loaded into the emulator, first call loadROM with the ROM's binary data then do the fixed nes.fromJSON above to load the save state.

Working example: http://tsbrom.com -- my NES Tecmo Super Bowl project for mobile devices ("Tecmo Touch")

@bfirsh I also have an Ionic5/Angular12 port of jsnes-web-react that I can send your way if interested.