### PR TITLE
Fix reset function / JSON serialization

### DIFF
--- a/src/nes.js
+++ b/src/nes.js
@@ -57,8 +57,8 @@ NES.prototype = {
   break: false,
 
   // Set break to true to stop frame loop.
-  stop: function() {
-   this.break = true;
+  stop: function () {
+    this.break = true;
   },
 
   // Resets the system
@@ -85,7 +85,7 @@ NES.prototype = {
     var ppu = this.ppu;
     var papu = this.papu;
     FRAMELOOP: for (;;) {
-      if(this.break) break;
+      if (this.break) break;
       if (cpu.cyclesToHalt === 0) {
         // Execute a CPU instruction
         cycles = cpu.emulate();

--- a/src/nes.js
+++ b/src/nes.js
@@ -54,6 +54,12 @@ var NES = function (opts) {
 NES.prototype = {
   fpsFrameCount: 0,
   romData: null,
+  break: false,
+
+  // Set break to true to stop frame loop.
+  stop: function() {
+   this.break = true;
+  },
 
   // Resets the system
   reset: function () {
@@ -67,6 +73,8 @@ NES.prototype = {
 
     this.lastFpsTime = null;
     this.fpsFrameCount = 0;
+
+    this.break = false;
   },
 
   frame: function () {
@@ -77,6 +85,7 @@ NES.prototype = {
     var ppu = this.ppu;
     var papu = this.papu;
     FRAMELOOP: for (;;) {
+      if(this.break) break;
       if (cpu.cyclesToHalt === 0) {
         // Execute a CPU instruction
         cycles = cpu.emulate();
@@ -192,19 +201,21 @@ NES.prototype = {
 
   toJSON: function () {
     return {
-      romData: this.romData,
+      // romData: this.romData,
       cpu: this.cpu.toJSON(),
       mmap: this.mmap.toJSON(),
       ppu: this.ppu.toJSON(),
+      papu: this.papu.toJSON(),
     };
   },
 
   fromJSON: function (s) {
     this.reset();
-    this.romData = s.romData;
+    // this.romData = s.romData;
     this.cpu.fromJSON(s.cpu);
     this.mmap.fromJSON(s.mmap);
     this.ppu.fromJSON(s.ppu);
+    this.papu.fromJSON(s.papu);
   },
 };
 

--- a/src/papu.js
+++ b/src/papu.js
@@ -986,7 +986,7 @@ ChannelDM.prototype = {
     "reg4013",
     "sample",
     "dacLsb",
-    "data"
+    "data",
   ],
 
   toJSON: function () {
@@ -1142,7 +1142,7 @@ ChannelNoise.prototype = {
     "sampleValue",
     "accValue",
     "accCount",
-    "tmp"
+    "tmp",
   ],
 
   toJSON: function () {

--- a/src/papu.js
+++ b/src/papu.js
@@ -1,3 +1,5 @@
+var utils = require("./utils");
+
 var CPU_FREQ_NTSC = 1789772.5; //1789772.72727272d;
 // var CPU_FREQ_PAL = 1773447.4;
 
@@ -718,6 +720,71 @@ PAPU.prototype = {
     this.dacRange = max_sqr + max_tnd;
     this.dcValue = this.dacRange / 2;
   },
+
+  JSON_PROPERTIES: [
+    "frameIrqCounter",
+    "frameIrqCounterMax",
+    "initCounter",
+    "channelEnableValue",
+    "sampleRate",
+    "frameIrqEnabled",
+    "frameIrqActive",
+    "frameClockNow",
+    "startedPlaying",
+    "recordOutput",
+    "initingHardware",
+    "masterFrameCounter",
+    "derivedFrameCounter",
+    "countSequence",
+    "sampleTimer",
+    "frameTime",
+    "sampleTimerMax",
+    "sampleCount",
+    "triValue",
+    "smpSquare1",
+    "smpSquare2",
+    "smpTriangle",
+    "smpDmc",
+    "accCount",
+    "prevSampleL",
+    "prevSampleR",
+    "smpAccumL",
+    "smpAccumR",
+    "masterVolume",
+    "stereoPosLSquare1",
+    "stereoPosLSquare2",
+    "stereoPosLTriangle",
+    "stereoPosLNoise",
+    "stereoPosLDMC",
+    "stereoPosRSquare1",
+    "stereoPosRSquare2",
+    "stereoPosRTriangle",
+    "stereoPosRNoise",
+    "stereoPosRDMC",
+    "extraCycles",
+    "maxSample",
+    "minSample",
+    "panning",
+  ],
+
+  toJSON: function () {
+    let obj = utils.toJSON(this);
+    obj.dmc = this.dmc.toJSON();
+    obj.noise = this.noise.toJSON();
+    obj.square1 = this.square1.toJSON();
+    obj.square2 = this.square2.toJSON();
+    obj.triangle = this.triangle.toJSON();
+    return obj;
+  },
+
+  fromJSON: function (s) {
+    utils.fromJSON(this, s);
+    this.dmc.fromJSON(s.dmc);
+    this.noise.fromJSON(s.noise);
+    this.square1.fromJSON(s.square1);
+    this.square2.fromJSON(s.square2);
+    this.triangle.fromJSON(s.triangle);
+  },
 };
 
 var ChannelDM = function (papu) {
@@ -898,6 +965,37 @@ ChannelDM.prototype = {
     this.reg4013 = 0;
     this.data = 0;
   },
+
+  JSON_PROPERTIES: [
+    "MODE_NORMAL",
+    "MODE_LOOP",
+    "MODE_IRQ",
+    "isEnabled",
+    "hasSample",
+    "irqGenerated",
+    "playMode",
+    "dmaFrequency",
+    "dmaCounter",
+    "deltaCounter",
+    "playStartAddress",
+    "playAddress",
+    "playLength",
+    "playLengthCounter",
+    "shiftCounter",
+    "reg4012",
+    "reg4013",
+    "sample",
+    "dacLsb",
+    "data"
+  ],
+
+  toJSON: function () {
+    return utils.toJSON(this);
+  },
+
+  fromJSON: function (s) {
+    utils.fromJSON(this, s);
+  },
 };
 
 var ChannelNoise = function (papu) {
@@ -1022,6 +1120,37 @@ ChannelNoise.prototype = {
 
   getLengthStatus: function () {
     return this.lengthCounter === 0 || !this.isEnabled ? 0 : 1;
+  },
+
+  JSON_PROPERTIES: [
+    "isEnabled",
+    "envDecayDisable",
+    "envDecayLoopEnable",
+    "lengthCounterEnable",
+    "envReset",
+    "shiftNow",
+    "lengthCounter",
+    "progTimerCount",
+    "progTimerMax",
+    "envDecayRate",
+    "envDecayCounter",
+    "envVolume",
+    "masterVolume",
+    "shiftReg",
+    "randomBit",
+    "randomMode",
+    "sampleValue",
+    "accValue",
+    "accCount",
+    "tmp"
+  ],
+
+  toJSON: function () {
+    return utils.toJSON(this);
+  },
+
+  fromJSON: function (s) {
+    utils.fromJSON(this, s);
   },
 };
 
@@ -1230,6 +1359,41 @@ ChannelSquare.prototype = {
   getLengthStatus: function () {
     return this.lengthCounter === 0 || !this.isEnabled ? 0 : 1;
   },
+
+  JSON_PROPERTIES: [
+    "isEnabled",
+    "lengthCounterEnable",
+    "sweepActive",
+    "envDecayDisable",
+    "envDecayLoopEnable",
+    "envReset",
+    "sweepCarry",
+    "updateSweepPeriod",
+    "progTimerCount",
+    "progTimerMax",
+    "lengthCounter",
+    "squareCounter",
+    "sweepCounter",
+    "sweepCounterMax",
+    "sweepMode",
+    "sweepShiftAmount",
+    "envDecayRate",
+    "envDecayCounter",
+    "envVolume",
+    "masterVolume",
+    "dutyMode",
+    "sweepResult",
+    "sampleValue",
+    "vol",
+  ],
+
+  toJSON: function () {
+    return utils.toJSON(this);
+  },
+
+  fromJSON: function (s) {
+    utils.fromJSON(this, s);
+  },
 };
 
 var ChannelTriangle = function (papu) {
@@ -1365,6 +1529,30 @@ ChannelTriangle.prototype = {
       this.progTimerMax > 7 &&
       this.linearCounter > 0 &&
       this.lengthCounter > 0;
+  },
+
+  JSON_PROPERTIES: [
+    "isEnabled",
+    "sampleCondition",
+    "lengthCounterEnable",
+    "lcHalt",
+    "lcControl",
+    "progTimerCount",
+    "progTimerMax",
+    "triangleCounter",
+    "lengthCounter",
+    "linearCounter",
+    "lcLoadValue",
+    "sampleValue",
+    "tmp",
+  ],
+
+  toJSON: function () {
+    return utils.toJSON(this);
+  },
+
+  fromJSON: function (s) {
+    utils.fromJSON(this, s);
   },
 };
 


### PR DESCRIPTION
Hi!

I'm creating a [mobile interface](https://ninjadynamics.github.io/nesdev/) for this emulator and since I was forced to change some stuff on the source code, I guess I should create a pull request. :)

Fixed the error `this.nes.stop is not a function` when calling `nes.reset()`:
- I copy-pasted some code from another fork, but I can't really remember where it took it from, sorry.

Improved JSON serialization:
- Commented out storing romData (which is the loaded ROM itself), for more efficient save/load state implementations
- Added APU serialization in order to get the sound to work properly after loading a serialized data
- Note that the object serialization itself has to be done on the implementation side.

**Save state**
- `const saveData = JSON.stringify(nes.toJSON());`

**Load state**
- `nes.fromJSON(JSON.parse(saveData));`
