### PR TITLE
Some minor accuracy fixes pertaining to audio & rendering

### DIFF
--- a/src/nes.js
+++ b/src/nes.js
@@ -6,7 +6,9 @@ var ROM = require("./rom");
 
 var NES = function (opts) {
   this.opts = {
+    onFrameStart: function () {},
     onFrame: function () {},
+    onFrameEnd: function () {},
     onAudioSample: null,
     onStatusUpdate: function () {},
     onBatteryRamWrite: function () {},
@@ -29,7 +31,9 @@ var NES = function (opts) {
   this.frameTime = 1000 / this.opts.preferredFrameRate;
 
   this.ui = {
+    writeFrameStart: this.opts.onFrameStart,
     writeFrame: this.opts.onFrame,
+    writeFrameEnd: this.opts.onFrameEnd,
     updateStatus: this.opts.onStatusUpdate,
   };
   this.cpu = new CPU(this);

--- a/src/tile.js
+++ b/src/tile.js
@@ -49,7 +49,8 @@ Tile.prototype = {
     flipHorizontal,
     flipVertical,
     pri,
-    priTable
+    priTable,
+    disableLeft8 = false
   ) {
     if (dx < -7 || dx >= 256 || dy < -7 || dy >= 240) {
       return;
@@ -85,7 +86,7 @@ Tile.prototype = {
           ) {
             this.palIndex = this.pix[this.tIndex];
             this.tpri = priTable[this.fbIndex];
-            if (this.palIndex !== 0 && pri <= (this.tpri & 0xff)) {
+            if (this.palIndex !== 0 && pri <= (this.tpri & 0xff) && (!disableLeft8 || this.fbIndex % 256 >= 8)) {
               //console.log("Rendering upright tile to buffer");
               buffer[this.fbIndex] = palette[this.palIndex + palAdd];
               this.tpri = (this.tpri & 0xf00) | pri;
@@ -111,7 +112,7 @@ Tile.prototype = {
           ) {
             this.palIndex = this.pix[this.tIndex];
             this.tpri = priTable[this.fbIndex];
-            if (this.palIndex !== 0 && pri <= (this.tpri & 0xff)) {
+            if (this.palIndex !== 0 && pri <= (this.tpri & 0xff) && (!disableLeft8 || this.fbIndex % 256 >= 8)) {
               buffer[this.fbIndex] = palette[this.palIndex + palAdd];
               this.tpri = (this.tpri & 0xf00) | pri;
               priTable[this.fbIndex] = this.tpri;
@@ -137,7 +138,7 @@ Tile.prototype = {
           ) {
             this.palIndex = this.pix[this.tIndex];
             this.tpri = priTable[this.fbIndex];
-            if (this.palIndex !== 0 && pri <= (this.tpri & 0xff)) {
+            if (this.palIndex !== 0 && pri <= (this.tpri & 0xff) && (!disableLeft8 || this.fbIndex % 256 >= 8)) {
               buffer[this.fbIndex] = palette[this.palIndex + palAdd];
               this.tpri = (this.tpri & 0xf00) | pri;
               priTable[this.fbIndex] = this.tpri;
@@ -163,7 +164,7 @@ Tile.prototype = {
           ) {
             this.palIndex = this.pix[this.tIndex];
             this.tpri = priTable[this.fbIndex];
-            if (this.palIndex !== 0 && pri <= (this.tpri & 0xff)) {
+            if (this.palIndex !== 0 && pri <= (this.tpri & 0xff) && (!disableLeft8 || this.fbIndex % 256 >= 8)) {
               buffer[this.fbIndex] = palette[this.palIndex + palAdd];
               this.tpri = (this.tpri & 0xf00) | pri;
               priTable[this.fbIndex] = this.tpri;


### PR DESCRIPTION
Hello,

I've added some changes to fix a few of the minor emulation inaccuracies I've noticed. Here are the main ones:
- The functionality of the BG clipping and Sprite clipping now work independently of each other, and the leftmost column now shows the BG color instead of a solid black (except for when TV clipping is enabled).
- Interpolation has been removed from the triangle channel so that it retains its characteristic "stair-step" wave pattern.
- Fixed an issue with the rightmost column of the screen not rendering correctly when TV clipping is disabled.
- All APU channels are now center-panned by default.
- NTSC palette modified to align more closely with the actual NTSC colors.

I've also added on a few small extra features:
- In addition to the APU panning table, I've added an APU volume mixer table, plus a table of "channel enable" flags, intended to be enabled/disable by the user via a GUI (and function independently of the register-controlled isEnabled flags).
- Added an "onFrameStart" callback option to the NES object, which is triggered when the top scanline is rendered as opposed to the bottom scanline like "onFrame".
- The TV clipping PPU flag has now been split into 2 separate flags for horizontal and vertical clipping. Only vertical is enabled by default.
