### PR TITLE
Improve frame loop performance by 15-20%

### DIFF
--- a/src/nes.js
+++ b/src/nes.js
@@ -109,6 +109,16 @@ NES.prototype = {
         }
       }
 
+      var finalCurX = ppu.curX + cycles;
+      if (
+        !ppu.requestEndFrame &&
+        finalCurX < 341 &&
+        (ppu.spr0HitX < ppu.curX || ppu.spr0HitX >= finalCurX)
+      ) {
+        ppu.curX = finalCurX;
+        continue FRAMELOOP;
+      }
+
       for (; cycles > 0; cycles--) {
         if (
           ppu.curX === ppu.spr0HitX &&


### PR DESCRIPTION
This commit increases the frame loop performance by 15-20%. How I tested it? I've turned on CPU throttling 6x in Chrome and I've run the below code.

```js
const results = new Array(30);
let pos = 0;

function onAnimationFrame() {
   const start = Date.now();
   nes.frame();
   const end = Date.now();
   results[pos] = end - start;
   pos = (pos + 1) % results.length;
   if (pos === 0) {
      const avg = results.reduce((a, b) => a + b, 0) / results.length;
      console.log(avg);
   }
   // ...
}
```

This improvement is felt well on slow phones.

## Results

Before my change:

<img width="618" alt="Screenshot 2022-10-19 at 23 49 22" src="https://user-images.githubusercontent.com/12797776/196812771-c7b4df86-bc5e-4ff4-8c63-fead7853cedf.png">

After my change:

<img width="618" alt="Screenshot 2022-10-19 at 23 48 42" src="https://user-images.githubusercontent.com/12797776/196813198-0c874132-06a5-4728-a525-687339c1e901.png">
