### PR TITLE
Add support for mapper 241

### DIFF
--- a/src/mappers.js
+++ b/src/mappers.js
@@ -1515,4 +1515,26 @@ Mappers[180].prototype.loadROM = function () {
   this.nes.cpu.requestIrq(this.nes.cpu.IRQ_RESET);
 };
 
+/**
+* Mapper 241 (BNROM, NINA-01)
+*
+* @description http://wiki.nesdev.com/w/index.php/INES_Mapper_241
+* @example 
+* @constructor https://blog.heheda.top
+*/
+Mappers[241] = function(nes) {
+			this.nes = nes;
+	};
+
+Mappers[241].prototype = new Mappers[0]();
+
+Mappers[241].prototype.write = function(address, value) {
+	 if (address < 0x8000) {
+			Mappers[0].prototype.write.apply(this, arguments);
+			return;
+		} else {
+			this.load32kRomBank(value, 0x8000);
+		}
+};
+
 module.exports = Mappers;


### PR DESCRIPTION
I tried adding mapper241 and tested it and found no exceptions for now.
The test screenshot is as follows:
![Tang Bohu's Autumn Fragrance Test Chart 1](https://user-images.githubusercontent.com/81669862/198289014-b0dc1ab6-ca1b-4bd4-a527-1978afd28e9d.png)
![Tang Bohu's Autumn Fragrance Test Chart 2](https://user-images.githubusercontent.com/81669862/198289341-e6e3ec73-9527-4b34-b58d-f992cc487b4b.png)
![Wong Fei Hung Test Chart 1](https://user-images.githubusercontent.com/81669862/198289430-3ee7e351-6606-4fdf-be6c-d4a863fc1d4c.png)
![Wong Fei Hung Test Chart 2](https://user-images.githubusercontent.com/81669862/198289611-2708beda-1b4a-43d3-ab4d-9a56f8187f62.png)