### PR TITLE
Add support for mapper 240

### DIFF
--- a/src/mappers.js
+++ b/src/mappers.js
@@ -1515,4 +1515,30 @@ Mappers[180].prototype.loadROM = function () {
   this.nes.cpu.requestIrq(this.nes.cpu.IRQ_RESET);
 };
 
+/**
+			 * Mapper 240
+			 *
+			 * @description https://www.nesdev.org/wiki/INES_Mapper_240
+			 * @example Jing Ke Xin Zhuan,Sheng Huo Lie Zhuan
+			 * @constructor https://blog.heheda.top
+			 */
+ Mappers[240] = function(nes) {
+  this.nes = nes;
+};
+
+Mappers[240].prototype = new Mappers[0]();
+
+Mappers[240].prototype.write = function(address, value) {
+  if (address < 0x4020 || address > 0x5FFF) {
+    Mappers[0].prototype.write.apply(this, arguments);
+    return;
+  } else {
+    // Swap in the given PRG-ROM bank at 0x8000:
+    this.load32kRomBank((value >> 4) & 3, 0x8000);
+
+    // Swap in the given VROM bank at 0x0000:
+    this.load8kVromBank((value & 0xf) * 2, 0x0000);
+  }
+};
+
 module.exports = Mappers;


### PR DESCRIPTION
Added support for mapper 240, which is common in some games released in China, I tried to write mapper 240, and apparently I did it successfully, and it worked!
I tried running Jing Ke Xin Zhuan and found no problems.
My English is not good, I'm sorry!
![demo image1](https://user-images.githubusercontent.com/81669862/192081691-92c50418-81f6-43b9-b37f-c0fada80b2f3.png)
![demo image2](https://user-images.githubusercontent.com/81669862/192081784-50005c1b-e9a3-4858-a6cc-cc5da3a9e2ff.png)
![demo image3](https://user-images.githubusercontent.com/81669862/192081798-e4fe373c-b0d2-4869-bdac-71c00acdc37e.png)
