### PR TITLE
Fix mmap is null error in cpu.js

### DIFF
--- a/src/cpu.js
+++ b/src/cpu.js
@@ -143,6 +143,7 @@ CPU.prototype = {
       this.irqRequested = false;
     }
 
+    if (null == this.nes.mmap) return 32;
     var opinf = this.opdata[this.nes.mmap.load(this.REG_PC + 1)];
     var cycleCount = opinf >> 24;
     var cycleAdd = 0;
@@ -1318,6 +1319,7 @@ CPU.prototype = {
   },
 
   doNonMaskableInterrupt: function (status) {
+    if (null == this.nes.mmap) return;
     if ((this.nes.mmap.load(0x2000) & 128) !== 0) {
       // Check whether VBlank Interrupts are enabled
 


### PR DESCRIPTION
During the first few frames of the emulator, an error is caused in the emulate() and doNonMaskableInterrupt() because this.nes.mmap is null. I added some guard clauses to prevent this error from occurring.