### PR TITLE
Add TypeScript type checking to CI pipeline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.2.1",
       "license": "Apache-2.0",
       "devDependencies": {
+        "@types/node": "^24.1.0",
         "chai": "^4.1.2",
         "eslint": "^6.8.0",
         "eslint-config-prettier": "^6.10.1",
@@ -17,6 +18,7 @@
         "prettier": "^3.6.2",
         "prettier-check": "^2.0.0",
         "sinon": "^21.0.0",
+        "typescript": "^5.8.3",
         "uglifyjs-webpack-plugin": "^1.3.0",
         "webpack": "^3.9.1"
       }
@@ -85,6 +87,16 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.1",
         "type-detect": "^4.1.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
+      "integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.8.0"
       }
     },
     "node_modules/@ungap/promise-all-settled": {
@@ -6712,6 +6724,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/uglify-es": {
       "version": "3.3.10",
       "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.10.tgz",
@@ -6933,6 +6959,13 @@
       "integrity": "sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/undici-types": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/union-value": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -12,12 +12,14 @@
   "license": "Apache-2.0",
   "scripts": {
     "build": "webpack",
-    "test": "prettier-check src/**/*.js && mocha ./test/*.spec.js",
+    "typecheck": "tsc --noEmit",
+    "test": "npm run typecheck && prettier-check src/**/*.js && mocha ./test/*.spec.js",
     "test:watch": "mocha -w ./test/*.spec.js",
     "prepublish": "npm run build",
     "format": "prettier --write src/**/*.js"
   },
   "devDependencies": {
+    "@types/node": "^24.1.0",
     "chai": "^4.1.2",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.10.1",
@@ -26,6 +28,7 @@
     "prettier": "^3.6.2",
     "prettier-check": "^2.0.0",
     "sinon": "^21.0.0",
+    "typescript": "^5.8.3",
     "uglifyjs-webpack-plugin": "^1.3.0",
     "webpack": "^3.9.1"
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": false,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "target": "es5",
+    "lib": ["es2015", "dom"]
+  },
+  "include": ["src/**/*.d.ts", "index.d.ts"],
+  "exclude": ["node_modules", "dist", "test"]
+}


### PR DESCRIPTION
## Summary
- Adds TypeScript type checking to the CI pipeline to ensure type definitions stay in sync with code changes
- Installs TypeScript and @types/node as dev dependencies  
- Creates tsconfig.json configured for type definition validation only
- Adds `typecheck` npm script and integrates it into the test suite

## Test plan
- [x] TypeScript type checking runs successfully locally (`npm run typecheck`)
- [x] Updated test script includes type checking (`npm test`)
- [x] CI pipeline will now validate types on every push/PR
- [x] Existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.ai/code)