### PR TITLE
Fix B flag incorrectly set during IRQ and NMI interrupts

### DIFF
--- a/src/cpu.js
+++ b/src/cpu.js
@@ -121,13 +121,15 @@ CPU.prototype = {
             // console.log("Interrupt was masked.");
             break;
           }
-          this.doIrq(temp);
+          // Clear the B flag (bit 4) for hardware interrupts
+          this.doIrq(temp & 0xef);
           // console.log("Did normal IRQ. I="+this.F_INTERRUPT);
           break;
         }
         case 1: {
           // NMI:
-          this.doNonMaskableInterrupt(temp);
+          // Clear the B flag (bit 4) for hardware interrupts
+          this.doNonMaskableInterrupt(temp & 0xef);
           break;
         }
         case 2: {


### PR DESCRIPTION
## Summary

- Fixes incorrect B flag behavior in IRQ and NMI interrupt handling
- On the 6502, the B flag (bit 4) should only be set in the pushed status byte for BRK instructions, not hardware interrupts
- This allows interrupt handlers to distinguish between software (BRK) and hardware (IRQ/NMI) interrupts

## Details

The fix clears bit 4 by masking the status with `0xEF` before passing it to `doIrq()` and `doNonMaskableInterrupt()`.

Fixes the B flag test in AccuracyCoin.

## Test plan

- [x] All existing tests pass (`npm test`)
- [x] Build succeeds (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)