### PR TITLE
Make ROM addresses (0x8000-0xFFFF) non-writable in Mapper 0

### DIFF
--- a/src/mappers.js
+++ b/src/mappers.js
@@ -21,12 +21,15 @@ Mappers[0].prototype = {
     if (address < 0x2000) {
       // Mirroring of RAM:
       this.nes.cpu.mem[address & 0x7ff] = value;
-    } else if (address > 0x4017) {
+    } else if (address >= 0x8000) {
+      // ROM is not writable. Mappers may override this to handle bank switching.
+    } else if (address >= 0x6000) {
+      // Cartridge SRAM (0x6000-0x7FFF)
       this.nes.cpu.mem[address] = value;
-      if (address >= 0x6000 && address < 0x8000) {
-        // Write to persistent RAM
-        this.nes.opts.onBatteryRamWrite(address, value);
-      }
+      this.nes.opts.onBatteryRamWrite(address, value);
+    } else if (address > 0x4017) {
+      // Cartridge expansion area (0x4018-0x5FFF)
+      this.nes.cpu.mem[address] = value;
     } else if (address > 0x2007 && address < 0x4000) {
       this.regWrite(0x2000 + (address & 0x7), value);
     } else {
@@ -38,7 +41,10 @@ Mappers[0].prototype = {
     if (address < 0x2000) {
       // Mirroring of RAM:
       this.nes.cpu.mem[address & 0x7ff] = value;
+    } else if (address >= 0x8000) {
+      // ROM is not writable
     } else if (address > 0x4017) {
+      // Cartridge RAM/expansion area (0x4018-0x7FFF)
       this.nes.cpu.mem[address] = value;
     } else if (address > 0x2007 && address < 0x4000) {
       this.regWrite(0x2000 + (address & 0x7), value);

--- a/test/mappers.spec.js
+++ b/test/mappers.spec.js
@@ -1,0 +1,77 @@
+var assert = require("chai").assert;
+var Mappers = require("../src/mappers");
+
+describe("Mappers", function () {
+  var mapper = null;
+  var mockNes = null;
+
+  beforeEach(function () {
+    // Create minimal mock NES with CPU memory
+    mockNes = {
+      cpu: {
+        mem: new Array(0x10000).fill(0),
+      },
+      opts: {
+        onBatteryRamWrite: function () {},
+      },
+    };
+    mapper = new Mappers[0](mockNes);
+    mapper.reset();
+  });
+
+  describe("write", function () {
+    it("does not modify ROM when writing to ROM addresses", function () {
+      // Set up some ROM data at 0x8000
+      var romAddress = 0x8000;
+      var originalValue = 0x42;
+      mockNes.cpu.mem[romAddress] = originalValue;
+
+      // Attempt to write a different value
+      var newValue = 0xff;
+      mapper.write(romAddress, newValue);
+
+      // Verify ROM was not modified
+      assert.equal(mockNes.cpu.mem[romAddress], originalValue);
+    });
+
+    it("does not modify ROM at high ROM addresses", function () {
+      var romAddress = 0xfffc;
+      var originalValue = 0xab;
+      mockNes.cpu.mem[romAddress] = originalValue;
+
+      mapper.write(romAddress, 0x00);
+
+      assert.equal(mockNes.cpu.mem[romAddress], originalValue);
+    });
+
+    it("allows writes to cartridge SRAM", function () {
+      var sramAddress = 0x6000;
+      mockNes.cpu.mem[sramAddress] = 0x00;
+
+      mapper.write(sramAddress, 0x42);
+
+      assert.equal(mockNes.cpu.mem[sramAddress], 0x42);
+    });
+
+    it("allows writes to RAM", function () {
+      var ramAddress = 0x0200;
+      mockNes.cpu.mem[ramAddress] = 0x00;
+
+      mapper.write(ramAddress, 0x42);
+
+      assert.equal(mockNes.cpu.mem[ramAddress & 0x7ff], 0x42);
+    });
+  });
+
+  describe("writelow", function () {
+    it("does not modify ROM when writing to ROM addresses", function () {
+      var romAddress = 0x8000;
+      var originalValue = 0x42;
+      mockNes.cpu.mem[romAddress] = originalValue;
+
+      mapper.writelow(romAddress, 0xff);
+
+      assert.equal(mockNes.cpu.mem[romAddress], originalValue);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Makes ROM addresses (0x8000-0xFFFF) non-writable, matching real NES hardware behavior
- Properly separates cartridge SRAM (0x6000-0x7FFF) with battery RAM callback
- Adds unit tests for mapper write behavior

## Details

On the NES, the ROM area cannot be written to by the CPU. Previously, writes to addresses >= 0x8000 would modify memory. This change makes those writes no-ops in both `write()` and `writelow()`.

The address space is now handled as:
- `0x0000-0x1FFF`: RAM (mirrored)
- `0x2000-0x3FFF`: PPU registers
- `0x4000-0x4017`: APU/IO registers  
- `0x4018-0x5FFF`: Cartridge expansion area
- `0x6000-0x7FFF`: Cartridge SRAM (with battery RAM callback)
- `0x8000-0xFFFF`: ROM (non-writable)

Fixes the "ROM is not writable" test in AccuracyCoin.

## Test plan

- [x] All existing tests pass (`npm test`)
- [x] New mapper tests verify ROM write protection

🤖 Generated with [Claude Code](https://claude.com/claude-code)