### PR TITLE
Fix infinite loop on invalid opcode

### DIFF
--- a/src/cpu.js
+++ b/src/cpu.js
@@ -1260,10 +1260,9 @@ CPU.prototype = {
         // * ??? *
         // *******
 
-        this.nes.stop();
-        this.nes.crashMessage =
-          "Game crashed, invalid opcode at address $" + opaddr.toString(16);
-        break;
+        throw new Error(
+          "Game crashed, invalid opcode at address $" + opaddr.toString(16),
+        );
       }
     } // end of switch
 

--- a/test/nes.spec.js
+++ b/test/nes.spec.js
@@ -50,6 +50,66 @@ describe("NES", function() {
     });
   });
 
+  describe("#frame() with invalid opcode", function() {
+    // Build a minimal iNES ROM (mapper 0, 1 PRG bank, 0 CHR banks)
+    // filled with 0x02 (an invalid opcode) so the CPU crashes immediately.
+    function makeInvalidOpcodeROM() {
+      var header = "NES\x1a" + // magic
+        "\x01" + // 1 PRG-ROM bank (16KB)
+        "\x00" + // 0 CHR-ROM banks
+        "\x00" + // flags 6: mapper 0, horizontal mirroring
+        "\x00" + // flags 7
+        "\x00\x00\x00\x00\x00\x00\x00\x00"; // padding
+      var prg = new Array(16384);
+      // Fill with invalid opcode 0x02
+      for (var i = 0; i < 16384; i++) {
+        prg[i] = 0x02;
+      }
+      // Set reset vector at 0xFFFC-0xFFFD to point to 0xC000
+      prg[0x3FFC] = 0x00; // low byte
+      prg[0x3FFD] = 0xC0; // high byte
+      var prgStr = "";
+      for (var j = 0; j < 16384; j++) {
+        prgStr += String.fromCharCode(prg[j]);
+      }
+      return header + prgStr;
+    }
+
+    it("throws an error on invalid opcode instead of looping infinitely", function() {
+      var nes = new NES();
+      nes.loadROM(makeInvalidOpcodeROM());
+      assert.throws(function() {
+        nes.frame();
+      }, /invalid opcode/);
+    });
+
+    it("marks NES as crashed and subsequent frame() throws", function() {
+      var nes = new NES();
+      nes.loadROM(makeInvalidOpcodeROM());
+      assert.throws(function() {
+        nes.frame();
+      }, /invalid opcode/);
+      assert.isTrue(nes.crashed);
+      // Subsequent calls to frame() should also throw
+      assert.throws(function() {
+        nes.frame();
+      }, /crashed/);
+    });
+
+    it("can be reset after crashing", function() {
+      var onFrame = sinon.spy();
+      var nes = new NES({ onFrame: onFrame });
+      nes.loadROM(makeInvalidOpcodeROM());
+      assert.throws(function() {
+        nes.frame();
+      }, /invalid opcode/);
+      assert.isTrue(nes.crashed);
+      // After reset, crashed flag is cleared
+      nes.reset();
+      assert.isFalse(nes.crashed);
+    });
+  });
+
   describe("#getFPS()", function() {
     var nes = new NES();
     before(function(done) {


### PR DESCRIPTION
## Summary

Fixes #24.

- CPU now throws an `Error` on invalid opcodes instead of silently setting a flag via `stop()`
- `NES.frame()` catches the error, marks the instance as `crashed`, and re-throws so callers can handle it
- Subsequent `frame()` calls throw immediately until `reset()` or `loadROM()` is called
- Removed the unused `stop()` method and `break` flag

## Test plan

- [x] New test: `frame()` throws on invalid opcode instead of looping infinitely
- [x] New test: NES is marked as crashed and subsequent `frame()` calls throw
- [x] New test: NES can be reset after crashing
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)