### PR TITLE
Fix getStatus/setStatus F_ZERO encoding

### DIFF
--- a/test/cpu.spec.js
+++ b/test/cpu.spec.js
@@ -106,7 +106,7 @@ describe("CPU", function () {
 
     function cpu_set_register(register, value) {
         if (register == 'P') {
-            cpu.setStatus(value ^ 0b10);
+            cpu.setStatus(value);
         } else {
             var reg = REGISTER_MAP[register];
             cpu[reg] = value;
@@ -116,7 +116,7 @@ describe("CPU", function () {
     function cpu_register(register) {
         var val = null
         if (register == 'P') {
-            return cpu.getStatus() ^ 0b10;
+            return cpu.getStatus();
         }
         var reg = REGISTER_MAP[register];
         var val = cpu[reg];


### PR DESCRIPTION
## Summary
- `F_ZERO` stores the raw result byte (0-255) as a performance optimization — 0 means Z is set, non-zero means clear. But `getStatus()` shifted this raw value directly into the status byte (corrupting bits when F_ZERO > 1), and `setStatus()` stored 0/1 with inverted polarity.
- Fix both functions to match the `(F_ZERO === 0 ? 1 : 0)` conversion already used in the inline status construction for PHP/BRK/interrupts.
- Remove the `^ 0b10` XOR hack in test helpers that was compensating for the broken encoding.
- Document the F_ZERO convention in `reset()`.

This also fixes JSON save/restore which round-trips through these functions.

## Test plan
- [x] All 312 tests pass
- [x] nestest ROM fully passes (bytes 0x02 and 0x03 both 0x00)

🤖 Generated with [Claude Code](https://claude.com/claude-code)