### PR TITLE
Fix RTI to ignore bits 4 and 5 from stack

### DIFF
--- a/src/cpu.js
+++ b/src/cpu.js
@@ -851,14 +851,13 @@ CPU.prototype = {
         // *******
 
         // Return from interrupt. Pull status and PC from stack.
+        // Bits 4 (B) and 5 (unused) are ignored, same as PLP.
 
         temp = this.pull();
         this.F_CARRY = temp & 1;
         this.F_ZERO = ((temp >> 1) & 1) === 0 ? 1 : 0;
         this.F_INTERRUPT = (temp >> 2) & 1;
         this.F_DECIMAL = (temp >> 3) & 1;
-        this.F_BRK = (temp >> 4) & 1;
-        this.F_NOTUSED = (temp >> 5) & 1;
         this.F_OVERFLOW = (temp >> 6) & 1;
         this.F_SIGN = (temp >> 7) & 1;
 
@@ -868,7 +867,6 @@ CPU.prototype = {
           return;
         }
         this.REG_PC--;
-        this.F_NOTUSED = 1;
         break;
       }
       case 42: {


### PR DESCRIPTION
## Summary
- Same fix as PLP: on the real 6502, bits 4 (B) and 5 (unused) don't exist as physical flags. RTI was setting F_BRK and F_NOTUSED from the pulled stack byte, but should ignore them.
- Confirmed against [nesdev wiki](https://www.nesdev.org/wiki/Instruction_reference#RTI): "The B flag and extra bit are ignored."

## Test plan
- [x] All 317 tests pass
- [x] nestest ROM fully passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)