### PR TITLE
Fix OAM DMA to copy all 256 bytes with wrapping

### DIFF
--- a/src/ppu.js
+++ b/src/ppu.js
@@ -755,15 +755,18 @@ PPU.prototype = {
   },
 
   // CPU Register $4014:
-  // Write 256 bytes of main memory
-  // into Sprite RAM.
+  // Write 256 bytes of main memory into Sprite RAM (OAM).
+  // DMA always copies exactly 256 bytes from CPU page $XX00-$XXFF.
+  // The destination starts at the current OAMADDR and wraps within OAM.
+  // See https://www.nesdev.org/wiki/PPU_registers#OAMDMA
   sramDMA: function (value) {
     var baseAddress = value * 0x100;
     var data;
-    for (var i = this.sramAddress; i < 256; i++) {
+    for (var i = 0; i < 256; i++) {
       data = this.nes.cpu.mem[baseAddress + i];
-      this.spriteMem[i] = data;
-      this.spriteRamWriteUpdate(i, data);
+      var oamAddr = (this.sramAddress + i) & 0xff;
+      this.spriteMem[oamAddr] = data;
+      this.spriteRamWriteUpdate(oamAddr, data);
     }
 
     this.nes.cpu.haltCycles(513);


### PR DESCRIPTION
## Summary
OAM DMA was incorrectly skipping the first bytes when OAMADDR was non-zero. Real hardware always copies exactly 256 bytes from the CPU page, with the destination starting at OAMADDR and wrapping within OAM.

## Changes
- Loop now iterates through all 256 source bytes
- Destination address uses modulo arithmetic to wrap within OAM
- Added documentation with reference to nesdev wiki

## Test Plan
- ✓ All 428 tests pass
- No new failures introduced