### PR TITLE
Move mapper names to mapper classes

### DIFF
--- a/src/mappers/mapper0.js
+++ b/src/mappers/mapper0.js
@@ -1,6 +1,8 @@
 import { copyArrayElements } from "../utils.js";
 
 class Mapper0 {
+  static mapperName = "NROM";
+
   constructor(nes) {
     this.nes = nes;
 

--- a/src/mappers/mapper1.js
+++ b/src/mappers/mapper1.js
@@ -1,6 +1,8 @@
 import Mapper0 from "./mapper0.js";
 
 class Mapper1 extends Mapper0 {
+  static mapperName = "MMC1";
+
   constructor(nes) {
     super(nes);
 

--- a/src/mappers/mapper11.js
+++ b/src/mappers/mapper11.js
@@ -7,6 +7,8 @@ import Mapper0 from "./mapper0.js";
  * @example Crystal Mines, Metal Fighter
  */
 class Mapper11 extends Mapper0 {
+  static mapperName = "Color Dreams";
+
   constructor(nes) {
     super(nes);
   }

--- a/src/mappers/mapper140.js
+++ b/src/mappers/mapper140.js
@@ -7,6 +7,8 @@ import Mapper0 from "./mapper0.js";
  * @example Bio Senshi Dan - Increaser Tono Tatakai
  */
 class Mapper140 extends Mapper0 {
+  static mapperName = "Jaleco JF-11/JF-14";
+
   constructor(nes) {
     super(nes);
   }

--- a/src/mappers/mapper180.js
+++ b/src/mappers/mapper180.js
@@ -7,6 +7,8 @@ import Mapper0 from "./mapper0.js";
  * @example Crazy Climber
  */
 class Mapper180 extends Mapper0 {
+  static mapperName = "UNROM (Crazy Climber)";
+
   constructor(nes) {
     super(nes);
   }

--- a/src/mappers/mapper2.js
+++ b/src/mappers/mapper2.js
@@ -1,6 +1,8 @@
 import Mapper0 from "./mapper0.js";
 
 class Mapper2 extends Mapper0 {
+  static mapperName = "UxROM";
+
   constructor(nes) {
     super(nes);
   }

--- a/src/mappers/mapper240.js
+++ b/src/mappers/mapper240.js
@@ -8,6 +8,8 @@ import Mapper0 from "./mapper0.js";
  * https://blog.heheda.top
  */
 class Mapper240 extends Mapper0 {
+  static mapperName = "Mapper 240";
+
   constructor(nes) {
     super(nes);
   }

--- a/src/mappers/mapper241.js
+++ b/src/mappers/mapper241.js
@@ -7,6 +7,8 @@ import Mapper0 from "./mapper0.js";
  * https://blog.heheda.top
  */
 class Mapper241 extends Mapper0 {
+  static mapperName = "BxROM (Mapper 241)";
+
   constructor(nes) {
     super(nes);
   }

--- a/src/mappers/mapper3.js
+++ b/src/mappers/mapper3.js
@@ -7,6 +7,8 @@ import Mapper0 from "./mapper0.js";
  * @description http://wiki.nesdev.com/w/index.php/INES_Mapper_003
  */
 class Mapper3 extends Mapper0 {
+  static mapperName = "CNROM";
+
   constructor(nes) {
     super(nes);
   }

--- a/src/mappers/mapper34.js
+++ b/src/mappers/mapper34.js
@@ -7,6 +7,8 @@ import Mapper0 from "./mapper0.js";
  * @example Darkseed, Mashou, Mission Impossible 2
  */
 class Mapper34 extends Mapper0 {
+  static mapperName = "BNROM";
+
   constructor(nes) {
     super(nes);
   }

--- a/src/mappers/mapper38.js
+++ b/src/mappers/mapper38.js
@@ -7,6 +7,8 @@ import Mapper0 from "./mapper0.js";
  * @example Crime Busters
  */
 class Mapper38 extends Mapper0 {
+  static mapperName = "PCI556";
+
   constructor(nes) {
     super(nes);
   }

--- a/src/mappers/mapper4.js
+++ b/src/mappers/mapper4.js
@@ -1,6 +1,7 @@
 import Mapper0 from "./mapper0.js";
 
 class Mapper4 extends Mapper0 {
+  static mapperName = "MMC3";
   static CMD_SEL_2_1K_VROM_0000 = 0;
   static CMD_SEL_2_1K_VROM_0800 = 1;
   static CMD_SEL_1K_VROM_1000 = 2;

--- a/src/mappers/mapper5.js
+++ b/src/mappers/mapper5.js
@@ -7,6 +7,8 @@ import Mapper0 from "./mapper0.js";
  * @description http://wiki.nesdev.com/w/index.php/INES_Mapper_005
  */
 class Mapper5 extends Mapper0 {
+  static mapperName = "MMC5";
+
   constructor(nes) {
     super(nes);
   }

--- a/src/mappers/mapper66.js
+++ b/src/mappers/mapper66.js
@@ -8,6 +8,8 @@ import Mapper0 from "./mapper0.js";
  * Super Mario Bros. + Duck Hunt
  */
 class Mapper66 extends Mapper0 {
+  static mapperName = "GxROM";
+
   constructor(nes) {
     super(nes);
   }

--- a/src/mappers/mapper7.js
+++ b/src/mappers/mapper7.js
@@ -6,6 +6,8 @@ import Mapper0 from "./mapper0.js";
  * @description http://wiki.nesdev.com/w/index.php/INES_Mapper_007
  */
 class Mapper7 extends Mapper0 {
+  static mapperName = "AxROM";
+
   constructor(nes) {
     super(nes);
   }

--- a/src/mappers/mapper94.js
+++ b/src/mappers/mapper94.js
@@ -7,6 +7,8 @@ import Mapper0 from "./mapper0.js";
  * @example Senjou no Ookami
  */
 class Mapper94 extends Mapper0 {
+  static mapperName = "UN1ROM";
+
   constructor(nes) {
     super(nes);
   }

--- a/src/rom.js
+++ b/src/rom.js
@@ -16,49 +16,6 @@ class ROM {
   constructor(nes) {
     this.nes = nes;
     this.valid = false;
-
-    this.mapperName = new Array(92);
-
-    for (let i = 0; i < 92; i++) {
-      this.mapperName[i] = "Unknown Mapper";
-    }
-    this.mapperName[0] = "Direct Access";
-    this.mapperName[1] = "Nintendo MMC1";
-    this.mapperName[2] = "UNROM";
-    this.mapperName[3] = "CNROM";
-    this.mapperName[4] = "Nintendo MMC3";
-    this.mapperName[5] = "Nintendo MMC5";
-    this.mapperName[6] = "FFE F4xxx";
-    this.mapperName[7] = "AOROM";
-    this.mapperName[8] = "FFE F3xxx";
-    this.mapperName[9] = "Nintendo MMC2";
-    this.mapperName[10] = "Nintendo MMC4";
-    this.mapperName[11] = "Color Dreams Chip";
-    this.mapperName[12] = "FFE F6xxx";
-    this.mapperName[15] = "100-in-1 switch";
-    this.mapperName[16] = "Bandai chip";
-    this.mapperName[17] = "FFE F8xxx";
-    this.mapperName[18] = "Jaleco SS8806 chip";
-    this.mapperName[19] = "Namcot 106 chip";
-    this.mapperName[20] = "Famicom Disk System";
-    this.mapperName[21] = "Konami VRC4a";
-    this.mapperName[22] = "Konami VRC2a";
-    this.mapperName[23] = "Konami VRC2a";
-    this.mapperName[24] = "Konami VRC6";
-    this.mapperName[25] = "Konami VRC4b";
-    this.mapperName[32] = "Irem G-101 chip";
-    this.mapperName[33] = "Taito TC0190/TC0350";
-    this.mapperName[34] = "32kB ROM switch";
-
-    this.mapperName[64] = "Tengen RAMBO-1 chip";
-    this.mapperName[65] = "Irem H-3001 chip";
-    this.mapperName[66] = "GNROM switch";
-    this.mapperName[67] = "SunSoft3 chip";
-    this.mapperName[68] = "SunSoft4 chip";
-    this.mapperName[69] = "SunSoft5 FME-7 chip";
-    this.mapperName[71] = "Camerica chip";
-    this.mapperName[78] = "Irem 74HC161/32-based";
-    this.mapperName[91] = "Pirate HK-SF3 chip";
   }
 
   load(data) {
@@ -186,13 +143,6 @@ class ROM {
     return this.VERTICAL_MIRRORING;
   }
 
-  getMapperName() {
-    if (this.mapperType >= 0 && this.mapperType < this.mapperName.length) {
-      return this.mapperName[this.mapperType];
-    }
-    return `Unknown Mapper, ${this.mapperType}`;
-  }
-
   mapperSupported() {
     return typeof Mappers[this.mapperType] !== "undefined";
   }
@@ -201,9 +151,7 @@ class ROM {
     if (this.mapperSupported()) {
       return new Mappers[this.mapperType](this.nes);
     } else {
-      throw new Error(
-        `This ROM uses a mapper not supported by JSNES: ${this.getMapperName()}(${this.mapperType})`,
-      );
+      throw new Error(`Unsupported mapper: ${this.mapperType}`);
     }
   }
 }


### PR DESCRIPTION
## Summary
- Move mapper name strings from a large array in `rom.js` to `static mapperName` properties on each mapper class
- Correct mapper names to match nesdev wiki nomenclature (e.g. "Direct Access" → "NROM", "AOROM" → "AxROM", "32kB ROM switch" → "BNROM")
- Remove the now-pointless `getMapperName()` method (it always returned "Unknown Mapper" for unsupported mappers since the name lookup only works for implemented mapper classes)

## Test plan
- [x] `npm test` passes (442 tests, 0 failures)
- [x] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)