### PR TITLE
Add support for mapper 71 (Camerica/Codemasters)

### DIFF
--- a/src/mappers/index.js
+++ b/src/mappers/index.js
@@ -9,6 +9,7 @@ import Mapper11 from "./mapper11.js";
 import Mapper34 from "./mapper34.js";
 import Mapper38 from "./mapper38.js";
 import Mapper66 from "./mapper66.js";
+import Mapper71 from "./mapper71.js";
 import Mapper94 from "./mapper94.js";
 import Mapper140 from "./mapper140.js";
 import Mapper180 from "./mapper180.js";
@@ -27,6 +28,7 @@ export default {
   34: Mapper34,
   38: Mapper38,
   66: Mapper66,
+  71: Mapper71,
   94: Mapper94,
   140: Mapper140,
   180: Mapper180,

--- a/src/mappers/mapper71.js
+++ b/src/mappers/mapper71.js
@@ -1,0 +1,50 @@
+import Mapper0 from "./mapper0.js";
+
+// Camerica/Codemasters mapper (BF9093/BF9097)
+// Used by games like Fire Hawk, Micro Machines, Bee 52, MiG 29, etc.
+// Largely a clone of UxROM with optional 1-screen mirroring control.
+// See https://www.nesdev.org/wiki/INES_Mapper_071
+class Mapper71 extends Mapper0 {
+  static mapperName = "Camerica";
+
+  constructor(nes) {
+    super(nes);
+  }
+
+  write(address, value) {
+    if (address < 0x8000) {
+      super.write(address, value);
+      return;
+    }
+
+    if (address >= 0x9000 && address < 0xa000) {
+      // $9000-$9FFF: 1-screen mirroring control (Fire Hawk / BF9097 variant)
+      // Bit 4 selects which CIRAM nametable to fill all four screen slots
+      if (value & 0x10) {
+        this.nes.ppu.setMirroring(this.nes.rom.SINGLESCREEN_MIRRORING2);
+      } else {
+        this.nes.ppu.setMirroring(this.nes.rom.SINGLESCREEN_MIRRORING);
+      }
+    } else if (address >= 0xc000) {
+      // $C000-$FFFF: PRG bank select (bits 3-0 select 16 KiB bank at $8000)
+      this.loadRomBank(value & 0x0f, 0x8000);
+    }
+  }
+
+  loadROM() {
+    if (!this.nes.rom.valid) {
+      throw new Error("Mapper 71: Invalid ROM! Unable to load.");
+    }
+
+    // Load first PRG bank at $8000, last at $C000 (fixed)
+    this.loadRomBank(0, 0x8000);
+    this.loadRomBank(this.nes.rom.romCount - 1, 0xc000);
+
+    // Load CHR-ROM (usually CHR-RAM, so this may be a no-op)
+    this.loadCHRROM();
+
+    this.nes.cpu.requestIrq(this.nes.cpu.IRQ_RESET);
+  }
+}
+
+export default Mapper71;


### PR DESCRIPTION
## Summary

Implements mapper 71, the Camerica/Codemasters mapper used by games like Fire Hawk, Micro Machines, Bee 52, and MiG 29. This mapper is largely a clone of UxROM (mapper 2) with additional features:

- 16 KiB PRG bank switching at $8000-$BFFF (fixed last bank at $C000-$FFFF)
- 1-screen mirroring control at $9000-$9FFF (Fire Hawk/BF9097 variant)
- 8 KiB CHR RAM (not bankswitched)

## Test plan

- All existing tests pass (442 passed, 0 failed)
- Tests cover CPU, PPU, mappers, and NES integration