### PR TITLE
Add detailed documentation comments to all mapper classes

### DIFF
--- a/src/mappers/mapper0.js
+++ b/src/mappers/mapper0.js
@@ -1,5 +1,9 @@
 import { copyArrayElements } from "../utils.js";
 
+// NROM - the simplest NES cartridge board (NES-NROM-128/NROM-256)
+// Used by games like Super Mario Bros., Donkey Kong, Excitebike.
+// No bank switching at all: 16 or 32 KB PRG-ROM, 8 KB CHR-ROM, fixed mirroring.
+// See https://www.nesdev.org/wiki/NROM
 class Mapper0 {
   static mapperName = "NROM";
 

--- a/src/mappers/mapper1.js
+++ b/src/mappers/mapper1.js
@@ -1,5 +1,11 @@
 import Mapper0 from "./mapper0.js";
 
+// MMC1 / SxROM (SKROM, SLROM, SNROM, etc.)
+// Used by games like The Legend of Zelda, Metroid, Mega Man 2, Final Fantasy.
+// Writes use a 5-bit serial shift register (5 consecutive writes to load a value).
+// Provides switchable 16 KB PRG-ROM banks, 4 KB or 8 KB CHR banks,
+// and software-controlled nametable mirroring.
+// See https://www.nesdev.org/wiki/MMC1
 class Mapper1 extends Mapper0 {
   static mapperName = "MMC1";
 

--- a/src/mappers/mapper11.js
+++ b/src/mappers/mapper11.js
@@ -1,11 +1,10 @@
 import Mapper0 from "./mapper0.js";
 
-/**
- * Mapper 011 (Color Dreams)
- *
- * @description http://wiki.nesdev.com/w/index.php/Color_Dreams
- * @example Crystal Mines, Metal Fighter
- */
+// Color Dreams (unlicensed discrete mapper)
+// Used by games like Bible Adventures, Crystal Mines, Chiller, Metal Fighter.
+// Single register at $8000-$FFFF: bits 0-1 select 32 KB PRG bank,
+// bits 4-7 select 8 KB CHR bank.
+// See https://www.nesdev.org/wiki/Color_Dreams
 class Mapper11 extends Mapper0 {
   static mapperName = "Color Dreams";
 

--- a/src/mappers/mapper140.js
+++ b/src/mappers/mapper140.js
@@ -1,11 +1,11 @@
 import Mapper0 from "./mapper0.js";
 
-/**
- * Mapper 140
- *
- * @description http://wiki.nesdev.com/w/index.php/INES_Mapper_140
- * @example Bio Senshi Dan - Increaser Tono Tatakai
- */
+// Jaleco JF-11 / JF-14
+// Used by Bio Senshi Dan - Increaser Tono Tatakai.
+// Similar to GxROM (mapper 66) but register is at $6000-$7FFF instead of $8000+,
+// which means it cannot coexist with SRAM. Bits 4-5 select 32 KB PRG bank,
+// bits 0-3 select 8 KB CHR bank.
+// See https://www.nesdev.org/wiki/INES_Mapper_140
 class Mapper140 extends Mapper0 {
   static mapperName = "Jaleco JF-11/JF-14";
 

--- a/src/mappers/mapper180.js
+++ b/src/mappers/mapper180.js
@@ -1,11 +1,11 @@
 import Mapper0 from "./mapper0.js";
 
-/**
- * Mapper 180
- *
- * @description http://wiki.nesdev.com/w/index.php/INES_Mapper_180
- * @example Crazy Climber
- */
+// UNROM (AND-logic variant, HVC-UNROM)
+// Used by Crazy Climber.
+// Inverted UxROM: first 16 KB bank fixed at $8000, switchable bank at $C000.
+// Standard UxROM fixes the last bank; this variant uses AND logic instead of OR logic
+// on the bank select lines, producing the opposite fixed-bank behavior.
+// See https://www.nesdev.org/wiki/INES_Mapper_180
 class Mapper180 extends Mapper0 {
   static mapperName = "UNROM (Crazy Climber)";
 

--- a/src/mappers/mapper2.js
+++ b/src/mappers/mapper2.js
@@ -1,5 +1,10 @@
 import Mapper0 from "./mapper0.js";
 
+// UxROM (NES-UNROM, NES-UOROM)
+// Used by games like Mega Man, Castlevania, Contra, Duck Tales, Metal Gear.
+// 16 KB switchable PRG-ROM bank at $8000, last 16 KB bank fixed at $C000.
+// Uses CHR-RAM (no CHR-ROM bank switching).
+// See https://www.nesdev.org/wiki/UxROM
 class Mapper2 extends Mapper0 {
   static mapperName = "UxROM";
 

--- a/src/mappers/mapper240.js
+++ b/src/mappers/mapper240.js
@@ -1,12 +1,10 @@
 import Mapper0 from "./mapper0.js";
 
-/**
- * Mapper 240
- *
- * @description https://www.nesdev.org/wiki/INES_Mapper_240
- * @example Jing Ke Xin Zhuan,Sheng Huo Lie Zhuan
- * https://blog.heheda.top
- */
+// Mapper 240 (Jing Ke Xin Zhuan / Sheng Huo Lie Zhuan PCBs)
+// Used by Jing Ke Xin Zhuan, Sheng Huo Lie Zhuan.
+// Register at $4020-$5FFF: upper nibble selects 32 KB PRG bank,
+// lower nibble selects 8 KB CHR bank.
+// See https://www.nesdev.org/wiki/INES_Mapper_240
 class Mapper240 extends Mapper0 {
   static mapperName = "Mapper 240";
 

--- a/src/mappers/mapper241.js
+++ b/src/mappers/mapper241.js
@@ -1,11 +1,10 @@
 import Mapper0 from "./mapper0.js";
 
-/**
- * Mapper 241 (BNROM, NINA-01)
- *
- * @description http://wiki.nesdev.com/w/index.php/INES_Mapper_241
- * https://blog.heheda.top
- */
+// BxROM variant (Hengge Technology)
+// Used by various Hengge Technology titles and educational cartridges.
+// BxROM-like 32 KB PRG bank switching via writes to $8000-$FFFF,
+// with optional battery-backed WRAM at $6000-$7FFF.
+// See https://www.nesdev.org/wiki/INES_Mapper_241
 class Mapper241 extends Mapper0 {
   static mapperName = "BxROM (Mapper 241)";
 

--- a/src/mappers/mapper3.js
+++ b/src/mappers/mapper3.js
@@ -1,11 +1,9 @@
 import Mapper0 from "./mapper0.js";
 
-/**
- * Mapper 003 (CNROM)
- *
- * @example Solomon's Key, Arkanoid, Arkista's Ring, Bump 'n' Jump, Cybernoid
- * @description http://wiki.nesdev.com/w/index.php/INES_Mapper_003
- */
+// CNROM
+// Used by games like Solomon's Key, Arkanoid, Arkista's Ring, Bump 'n' Jump.
+// Fixed PRG-ROM (up to 32 KB), with switchable 8 KB CHR-ROM banks.
+// See https://www.nesdev.org/wiki/INES_Mapper_003
 class Mapper3 extends Mapper0 {
   static mapperName = "CNROM";
 

--- a/src/mappers/mapper34.js
+++ b/src/mappers/mapper34.js
@@ -1,11 +1,11 @@
 import Mapper0 from "./mapper0.js";
 
-/**
- * Mapper 034 (BNROM, NINA-01)
- *
- * @description http://wiki.nesdev.com/w/index.php/INES_Mapper_034
- * @example Darkseed, Mashou, Mission Impossible 2
- */
+// BNROM (NES-BNROM)
+// Used by games like Deadly Towers (Mashou), Darkseed.
+// Simple 32 KB PRG-ROM bank switching via writes to $8000-$FFFF.
+// No CHR bank switching (uses CHR-RAM or fixed CHR-ROM).
+// Note: iNES mapper 34 also covers NINA-001; this implementation handles BNROM only.
+// See https://www.nesdev.org/wiki/INES_Mapper_034
 class Mapper34 extends Mapper0 {
   static mapperName = "BNROM";
 

--- a/src/mappers/mapper38.js
+++ b/src/mappers/mapper38.js
@@ -1,11 +1,10 @@
 import Mapper0 from "./mapper0.js";
 
-/**
- * Mapper 038
- *
- * @description http://wiki.nesdev.com/w/index.php/INES_Mapper_038
- * @example Crime Busters
- */
+// PCI556 (UNL-PCI556) - Bit Corp
+// Used by Crime Busters.
+// Nearly identical to GxROM (mapper 66) but the register is at $7000-$7FFF.
+// Bits 0-1 select 32 KB PRG bank, bits 2-3 select 8 KB CHR bank.
+// See https://www.nesdev.org/wiki/INES_Mapper_038
 class Mapper38 extends Mapper0 {
   static mapperName = "PCI556";
 

--- a/src/mappers/mapper4.js
+++ b/src/mappers/mapper4.js
@@ -1,5 +1,11 @@
 import Mapper0 from "./mapper0.js";
 
+// MMC3 / TxROM (TSROM, TLSROM, TQROM, etc.)
+// Used by games like Super Mario Bros. 2, Super Mario Bros. 3, Kirby's Adventure.
+// Fine-grained bank switching: two 8 KB switchable PRG-ROM banks, two 2 KB + four
+// 1 KB CHR banks. Provides a scanline-counting IRQ for split-screen effects and
+// software-switchable H/V nametable mirroring.
+// See https://www.nesdev.org/wiki/MMC3
 class Mapper4 extends Mapper0 {
   static mapperName = "MMC3";
   static CMD_SEL_2_1K_VROM_0000 = 0;

--- a/src/mappers/mapper5.js
+++ b/src/mappers/mapper5.js
@@ -1,11 +1,12 @@
 import Mapper0 from "./mapper0.js";
 
-/**
- * Mapper005 (MMC5,ExROM)
- *
- * @example Castlevania 3, Just Breed, Uncharted Waters, Romance of the 3 Kingdoms 2, Laser Invasion, Metal Slader Glory, Uchuu Keibitai SDF, Shin 4 Nin Uchi Mahjong - Yakuman Tengoku
- * @description http://wiki.nesdev.com/w/index.php/INES_Mapper_005
- */
+// MMC5 / ExROM (EKROM, ELROM, ETROM, EWROM)
+// Used by games like Castlevania III, Just Breed, Uncharted Waters, Metal Slader Glory.
+// The most complex Nintendo mapper. Flexible PRG/CHR banking (up to 1 MB each),
+// expansion audio (2 pulse + PCM), 8x8 hardware multiplier, 1 KB ExRAM for extended
+// nametable attributes, vertical split screen, and scanline-counting IRQ.
+// NOTE: This implementation is incomplete (stub).
+// See https://www.nesdev.org/wiki/MMC5
 class Mapper5 extends Mapper0 {
   static mapperName = "MMC5";
 

--- a/src/mappers/mapper66.js
+++ b/src/mappers/mapper66.js
@@ -1,12 +1,10 @@
 import Mapper0 from "./mapper0.js";
 
-/**
- * Mapper 066 (GxROM)
- *
- * @description http://wiki.nesdev.com/w/index.php/INES_Mapper_066
- * @example Doraemon, Dragon Power, Gumshoe, Thunder & Lightning,
- * Super Mario Bros. + Duck Hunt
- */
+// GxROM (NES-GNROM, NES-MHROM)
+// Used by games like Doraemon, Dragon Power, Gumshoe, Super Mario Bros. + Duck Hunt.
+// Discrete mapper with 32 KB PRG and 8 KB CHR bank switching via a single register
+// at $8000-$FFFF. Bits 4-5 select PRG bank, bits 0-1 select CHR bank.
+// See https://www.nesdev.org/wiki/GxROM
 class Mapper66 extends Mapper0 {
   static mapperName = "GxROM";
 

--- a/src/mappers/mapper7.js
+++ b/src/mappers/mapper7.js
@@ -1,10 +1,10 @@
 import Mapper0 from "./mapper0.js";
 
-/**
- * Mapper007 (AxROM)
- * @example Battletoads, Time Lord, Marble Madness
- * @description http://wiki.nesdev.com/w/index.php/INES_Mapper_007
- */
+// AxROM (NES-AMROM, NES-ANROM, NES-AOROM)
+// Used by games like Battletoads, Marble Madness, Wizards & Warriors.
+// 32 KB switchable PRG-ROM bank (bits 0-2) with single-screen nametable mirroring
+// select (bit 4). Uses CHR-RAM, no CHR bank switching.
+// See https://www.nesdev.org/wiki/AxROM
 class Mapper7 extends Mapper0 {
   static mapperName = "AxROM";
 

--- a/src/mappers/mapper94.js
+++ b/src/mappers/mapper94.js
@@ -1,11 +1,10 @@
 import Mapper0 from "./mapper0.js";
 
-/**
- * Mapper 094 (UN1ROM)
- *
- * @description http://wiki.nesdev.com/w/index.php/INES_Mapper_094
- * @example Senjou no Ookami
- */
+// UN1ROM (HVC-UN1ROM)
+// Used by Senjou no Ookami (Commando).
+// UxROM variant where the bank number is in bits 2-4 instead of bits 0-2.
+// 16 KB switchable PRG-ROM at $8000, last 16 KB bank fixed at $C000.
+// See https://www.nesdev.org/wiki/INES_Mapper_094
 class Mapper94 extends Mapper0 {
   static mapperName = "UN1ROM";
 


### PR DESCRIPTION
## Summary

Researched each NES mapper on the nesdev wiki and added consistent documentation comments across all 16 mapper implementations. Each mapper now includes:
- Board name and hardware variants  
- Notable games using the mapper
- Technical description of banking scheme and capabilities
- Link to nesdev wiki reference

Standardized on the clear comment style already used for mapper 71 (Camerica) for consistency.

## Test Plan

- All existing tests pass (442 pass, 0 fail)
- Code formatting verified with Prettier
- No functional changes, documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)