### PR TITLE
Add support for mapper 79 (NINA-03/NINA-06)

### DIFF
--- a/src/mappers/index.js
+++ b/src/mappers/index.js
@@ -10,6 +10,7 @@ import Mapper34 from "./mapper34.js";
 import Mapper38 from "./mapper38.js";
 import Mapper66 from "./mapper66.js";
 import Mapper71 from "./mapper71.js";
+import Mapper79 from "./mapper79.js";
 import Mapper94 from "./mapper94.js";
 import Mapper140 from "./mapper140.js";
 import Mapper180 from "./mapper180.js";
@@ -29,6 +30,7 @@ export default {
   38: Mapper38,
   66: Mapper66,
   71: Mapper71,
+  79: Mapper79,
   94: Mapper94,
   140: Mapper140,
   180: Mapper180,

--- a/src/mappers/mapper79.js
+++ b/src/mappers/mapper79.js
@@ -1,0 +1,33 @@
+import Mapper0 from "./mapper0.js";
+
+// NINA-03/NINA-06 (American Video Entertainment)
+// Used by games like Tiles of Fate, Krazy Kreatures, Impossible Mission II.
+// GxROM-like mapper with the register in the expansion area ($4100-$5FFF)
+// instead of the cartridge space. Address decode: (addr & $E100) == $4100.
+// Register format: .... PCCC
+//   P (bit 3): selects 32 KB PRG bank
+//   CCC (bits 0-2): selects 8 KB CHR bank
+// See https://www.nesdev.org/wiki/INES_Mapper_079
+class Mapper79 extends Mapper0 {
+  static mapperName = "NINA-03/NINA-06";
+
+  constructor(nes) {
+    super(nes);
+  }
+
+  write(address, value) {
+    // The NINA register is active at addresses where (address & $E100) == $4100.
+    // This covers $4100-$41FF, $4300-$43FF, $4500-$45FF, ... $5F00-$5FFF.
+    if ((address & 0xe100) === 0x4100) {
+      // Swap 32 KB PRG bank based on bit 3
+      this.load32kRomBank((value >> 3) & 1, 0x8000);
+
+      // Swap 8 KB CHR bank based on bits 0-2
+      this.load8kVromBank((value & 7) * 2, 0x0000);
+    }
+
+    super.write(address, value);
+  }
+}
+
+export default Mapper79;


### PR DESCRIPTION
## Summary
Implement NINA-03/NINA-06 mapper used by games like Tiles of Fate and Krazy Kreatures. The register is located in the CPU expansion area ($4100-$5FFF) instead of cartridge space, with bit 3 selecting the 32 KB PRG bank and bits 0-2 selecting the 8 KB CHR bank.

## Test plan
- All existing tests pass (442 passing, 0 failures)
- Mapper properly handles address decode pattern: (address & 0xE100) == 0x4100

🤖 Generated with [Claude Code](https://claude.com/claude-code)