### PR TITLE
Fix sprite 0 hit to require actual background tile pixel

### DIFF
--- a/src/ppu/index.js
+++ b/src/ppu/index.js
@@ -1106,6 +1106,12 @@ class PPU {
     }
   }
 
+  // Check if sprite 0 overlaps with a background tile pixel on this scanline.
+  // On real hardware, sprite 0 hit only fires when a non-transparent sprite
+  // pixel overlaps with a non-transparent background tile pixel. We check
+  // pixrendered[bufferIndex] > 0xff because bit 8 (256) is set by
+  // renderBgScanline when an actual background tile pixel is rendered.
+  // See https://www.nesdev.org/wiki/PPU_OAM#Sprite_zero_hits
   checkSprite0(scan) {
     this.spr0HitX = -1;
     this.spr0HitY = -1;
@@ -1141,7 +1147,7 @@ class PPU {
               if (
                 bufferIndex >= 0 &&
                 bufferIndex < 61440 &&
-                this.pixrendered[bufferIndex] !== 0
+                this.pixrendered[bufferIndex] > 0xff
               ) {
                 if (t.pix[toffset + i] !== 0) {
                   this.spr0HitX = bufferIndex % 256;
@@ -1159,7 +1165,7 @@ class PPU {
               if (
                 bufferIndex >= 0 &&
                 bufferIndex < 61440 &&
-                this.pixrendered[bufferIndex] !== 0
+                this.pixrendered[bufferIndex] > 0xff
               ) {
                 if (t.pix[toffset + i] !== 0) {
                   this.spr0HitX = bufferIndex % 256;
@@ -1218,7 +1224,7 @@ class PPU {
               if (
                 bufferIndex >= 0 &&
                 bufferIndex < 61440 &&
-                this.pixrendered[bufferIndex] !== 0
+                this.pixrendered[bufferIndex] > 0xff
               ) {
                 if (t.pix[toffset + i] !== 0) {
                   this.spr0HitX = bufferIndex % 256;
@@ -1236,7 +1242,7 @@ class PPU {
               if (
                 bufferIndex >= 0 &&
                 bufferIndex < 61440 &&
-                this.pixrendered[bufferIndex] !== 0
+                this.pixrendered[bufferIndex] > 0xff
               ) {
                 if (t.pix[toffset + i] !== 0) {
                   this.spr0HitX = bufferIndex % 256;


### PR DESCRIPTION
## Summary

- Fixes sprite 0 hit detection in `checkSprite0()` to require an actual background tile pixel, matching real NES hardware behavior
- The old check (`pixrendered[bufferIndex] !== 0`) always passed because `pixrendered` is initialized to 65 in `startFrame()`, causing sprite 0 hit to fire at wrong positions
- Changed to `pixrendered[bufferIndex] > 0xff` which checks bit 8 (set by `renderBgScanline` when a background tile pixel is rendered), consistent with background detection elsewhere in the PPU

## Test plan

- [x] All 442 tests pass (0 failures)
- [x] Benchmark shows no performance regression (~1922 fps, above ~1800 baseline)
- [ ] Test with Antarctic Adventure and Karateka ROMs to verify freeze is resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)