### PR TITLE
Add Vercel SPA routing config to fix 404 on direct navigation

### DIFF
--- a/web/vercel.json
+++ b/web/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Direct navigation to routes like `/run/accuracycoin` returned 404 on Vercel because the deployment platform looked for matching files on disk instead of serving the SPA index.html. This adds a Vercel configuration file with a rewrite rule that matches the existing Netlify `_redirects` setup, enabling React Router to handle all routes client-side.

## Test plan

- Deploy to Vercel
- Navigate directly to a ROM URL like `/run/accuracycoin`
- Verify the page loads instead of showing 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)