### PR TITLE
Remove known failure for t register quirks PPU test

### DIFF
--- a/test/accuracycoin.spec.js
+++ b/test/accuracycoin.spec.js
@@ -300,7 +300,6 @@ const KNOWN_FAILURES = {
 
   // PPU misc: need dot-accurate PPU rendering pipeline
   0x0481: "Attributes as tiles not accurate",
-  0x0482: "t register quirks not accurate",
   0x0483: "Stale BG shift registers not accurate",
   0x0487: "BG serial in not accurate",
   0x0484: "Sprites on scanline 0 not accurate",


### PR DESCRIPTION
This change removes a known failure entry from the test suite, indicating that the t register quirks PPU rendering issue has been resolved.

## Summary
Removed the known failure entry for test case 0x0482 ("t register quirks not accurate") from the KNOWN_FAILURES object in the test specification file.

## Key Changes
- Removed the line marking test 0x0482 as a known failure, suggesting the underlying PPU t register quirks implementation has been fixed and the test now passes

## Details
The t register is a critical component of the NES PPU's address generation logic. This removal indicates that the emulator's PPU rendering pipeline now accurately handles t register behavior, allowing this previously failing test to pass.

https://claude.ai/code/session_01AW6g5PkiBiqmSHzfZki7Dz