### PR TITLE
Refactor frame rate handling to decouple from preferred frame rate

### DIFF
--- a/src/nes.d.ts
+++ b/src/nes.d.ts
@@ -12,7 +12,6 @@ export interface NESOptions {
   onAudioSample?: (left: number, right: number) => void;
   onStatusUpdate?: (status: string) => void;
   onBatteryRamWrite?: (address: number, value: number) => void;
-  preferredFrameRate?: number;
   emulateSound?: boolean;
   sampleRate?: number;
 }

--- a/src/nes.js
+++ b/src/nes.js
@@ -13,16 +13,11 @@ class NES {
       onStatusUpdate: function () {},
       onBatteryRamWrite: function () {},
 
-      // FIXME: not actually used except for in PAPU
-      preferredFrameRate: 60,
-
       emulateSound: true,
       sampleRate: 48000, // Sound sample rate in hz
 
       ...opts,
     };
-
-    this.frameTime = 1000 / this.opts.preferredFrameRate;
 
     this.ui = {
       writeFrame: this.opts.onFrame,
@@ -171,10 +166,12 @@ class NES {
     this.romData = data;
   }
 
+  // Adjust audio sample timing for a non-standard host frame rate. At the
+  // default 60fps each frame() produces ~800 samples at 48kHz. If the host
+  // calls frame() less often (e.g. 30fps), the sample timer must fire more
+  // frequently per CPU cycle so each frame still fills the audio buffer.
   setFramerate(rate) {
-    this.opts.preferredFrameRate = rate;
-    this.frameTime = 1000 / rate;
-    this.papu.setSampleRate(this.opts.sampleRate, false);
+    this.papu.setFrameRate(rate);
   }
 
   toJSON() {

--- a/src/papu/index.js
+++ b/src/papu/index.js
@@ -65,8 +65,7 @@ class PAPU {
 
     this.sampleRate = this.nes.opts.sampleRate;
     this.sampleTimerMax = Math.floor(
-      (1024.0 * CPU_FREQ_NTSC * this.nes.opts.preferredFrameRate) /
-        (this.sampleRate * 60.0),
+      (1024.0 * CPU_FREQ_NTSC) / this.sampleRate,
     );
     this.sampleTimer = 0;
     this.updateChannelEnable(0);
@@ -598,6 +597,16 @@ class PAPU {
       return this.noiseWavelengthLookup[value];
     }
     return 0;
+  }
+
+  // Recalculate the sample timer for a non-standard host frame rate.
+  // At 60fps the timer fires once per (CPU_FREQ / sampleRate) cycles. If the
+  // host calls frame() at a different rate, scale proportionally so the total
+  // audio output per second stays constant.
+  setFrameRate(rate) {
+    this.sampleTimerMax = Math.floor(
+      (1024.0 * CPU_FREQ_NTSC * rate) / (this.sampleRate * 60.0),
+    );
   }
 
   setPanning(pos) {


### PR DESCRIPTION
## Summary
This PR refactors the frame rate handling logic to better separate concerns between the NES emulator's frame rate and audio sample timing. The `preferredFrameRate` option has been removed and replaced with a dedicated `setFrameRate()` method in the PAPU (audio) module that properly scales audio sample timing based on the host's actual frame rate.

## Key Changes
- Removed `preferredFrameRate` option from NES class and TypeScript definitions
- Removed `frameTime` calculation from NES constructor (was only used by PAPU)
- Simplified `sampleTimerMax` calculation in PAPU to use only CPU frequency and sample rate (removing the frame rate dependency from initialization)
- Added new `setFrameRate(rate)` method to PAPU that dynamically adjusts `sampleTimerMax` based on the host's frame rate
- Updated `NES.setFramerate()` to call the new `PAPU.setFrameRate()` method instead of recalculating sample rate

## Implementation Details
The audio sample timing now correctly scales proportionally when the host calls `frame()` at a non-standard rate. At 60fps, the sample timer fires at the standard interval. If the host runs at a different frame rate (e.g., 30fps), the sample timer is scaled so that the total audio output per second remains constant. This is achieved by the formula: `sampleTimerMax = (1024.0 * CPU_FREQ_NTSC * rate) / (sampleRate * 60.0)`, where `rate` is the host's actual frame rate.

https://claude.ai/code/session_01CSEqJeZdPTXB1amS9gK7VC