### PR TITLE
Fix PRG-ROM loading to account for optional trainer data

### DIFF
--- a/src/rom.js
+++ b/src/rom.js
@@ -70,7 +70,9 @@ class ROM {
     }
     // Load PRG-ROM banks:
     this.rom = new Array(this.romCount);
-    let offset = 16;
+    // Skip past the 16-byte header, plus 512-byte trainer if present.
+    // See https://www.nesdev.org/wiki/INES#Trainer
+    let offset = 16 + (this.trainer ? 512 : 0);
     for (i = 0; i < this.romCount; i++) {
       this.rom[i] = new Uint8Array(16384);
       for (j = 0; j < 16384; j++) {


### PR DESCRIPTION
## Summary
Fixed a bug in ROM loading where the PRG-ROM bank offset calculation did not account for the optional 512-byte trainer section in iNES format files.

## Key Changes
- Updated the PRG-ROM offset calculation to skip past both the 16-byte iNES header and the optional 512-byte trainer section when present
- The offset is now calculated as `16 + (this.trainer ? 512 : 0)` instead of always using a fixed offset of `16`
- Added clarifying comments with a reference to the iNES format specification

## Implementation Details
The iNES ROM format includes an optional trainer section that, when present, must be skipped before reading the actual PRG-ROM data. The previous implementation always assumed the PRG-ROM data started at byte 16, which would cause incorrect data to be loaded for ROM files containing a trainer. This fix ensures the loader correctly handles both trainer and non-trainer iNES files.

https://claude.ai/code/session_01BjrLQM4ThpZ1x4uNUdaThQ