### PR TITLE
Configure Dependabot to group React updates together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,11 @@ updates:
   schedule:
     interval: weekly
   open-pull-requests-limit: 10
+  # Group related packages so they update together in a single PR. React and
+  # react-dom must be on the exact same version or the app fails to start, so
+  # they must always be bumped in tandem.
+  groups:
+    react:
+      patterns:
+        - "react"
+        - "react-dom"

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -11,8 +11,8 @@
       "dependencies": {
         "jsnes": "file:..",
         "prop-types": "^15.8.1",
-        "react": "^19.2.4",
-        "react-dom": "^19.2.4",
+        "react": "^19.2.5",
+        "react-dom": "^19.2.5",
         "react-router-dom": "^7.14.1"
       },
       "devDependencies": {
@@ -27,7 +27,6 @@
       }
     },
     "..": {
-      "name": "jsnes",
       "version": "2.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
@@ -2072,24 +2071,24 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
-      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
-      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.4"
+        "react": "^19.2.5"
       }
     },
     "node_modules/react-is": {

--- a/web/package.json
+++ b/web/package.json
@@ -7,8 +7,8 @@
     "jsnes": "file:..",
     "prop-types": "^15.8.1",
 
-    "react": "^19.2.4",
-    "react-dom": "^19.2.4",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5",
     "react-router-dom": "^7.14.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
This PR configures Dependabot to group React and react-dom package updates into a single pull request, ensuring they are always bumped together to maintain version parity.

## Key Changes
- Added Dependabot grouping configuration in `.github/dependabot.yml` to create a "react" group that includes both `react` and `react-dom` packages
- Updated React and react-dom from `^19.2.4` to `^19.2.5` in `web/package.json`

## Implementation Details
The Dependabot configuration now includes a `groups` section that defines a "react" group with pattern matching for both `react` and `react-dom`. This ensures these two packages, which must maintain version parity for the application to function correctly, will always be updated together in a single PR rather than as separate dependency updates.

https://claude.ai/code/session_011Fqkmphv2jxynoKRq5xLws